### PR TITLE
Draft: Add SiliconLabs/arduino framework and ThingPlusMatter board

### DIFF
--- a/boards/sparkfun_thingplusmatter.json
+++ b/boards/sparkfun_thingplusmatter.json
@@ -1,0 +1,33 @@
+{
+  "build": {
+    "core": "silabs",
+    "f_cpu": "39000000L",
+    "mcu": "cortex-m33",
+    "variant": "thingplusmatter"
+  },
+  "connectivity": [
+    "bluetooth",
+    "thread",
+    "wifi",
+    "zigbee"
+  ],
+  "debug": {
+    "jlink_device": "EFR32MG24B020F1536IM40",
+    "onboard_tools": [
+      "jlink"
+    ],
+    "svd_path": "EFR32MG24B020F1536IM40.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Sparkfun Thing Plus Matter",
+  "upload": {
+    "flash_size": "1536kB",
+    "maximum_ram_size": 262144,
+    "maximum_size": 1572864,
+    "protocol": "jlink"
+  },
+  "url": "https://www.sparkfun.com/products/20270",
+  "vendor": "Sparkfun"
+}

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Arduino
+
+Arduino Wiring-based Framework allows writing cross-platform software to
+control devices attached to a wide range of Arduino boards to create all
+kinds of creative coding, interactive objects, spaces or physical experiences.
+
+https://github.com/SiliconLabs/arduino
+"""
+
+from os.path import isdir, join
+
+from SCons.Script import DefaultEnvironment
+
+env = DefaultEnvironment()
+platform = env.PioPlatform()
+board = env.BoardConfig()
+
+FRAMEWORK_DIR = platform.get_package_dir("framework-arduino-silabs")
+assert isdir(FRAMEWORK_DIR)
+
+
+# TODO
+# for sub-variants matter. ble, noradio
+# get cflags, cxxflags, ldflags etc. from
+# https://github.com/SiliconLabs/arduino/blob/main/platform.txt
+# https://github.com/SiliconLabs/arduino/blob/main/boards.txt
+
+
+#
+# Target: Build Core Library
+#
+
+libs = []
+
+if "build.variant" in board:
+    env.Append(CPPPATH=[
+        join(FRAMEWORK_DIR, "variants", board.get("build.variant"))
+    ])
+
+    libs.append(
+        env.BuildLibrary(
+            join("$BUILD_DIR", "FrameworkArduinoVariant"),
+            join(FRAMEWORK_DIR, "variants", board.get("build.variant"))))
+
+libs.append(
+    env.BuildLibrary(
+        join("$BUILD_DIR", "FrameworkArduino"),
+        join(FRAMEWORK_DIR, "cores", board.get("build.core"))))
+
+env.Prepend(LIBS=libs)

--- a/platform.json
+++ b/platform.json
@@ -28,16 +28,22 @@
     "zephyr": {
       "package": "framework-zephyr",
       "script": "builder/frameworks/zephyr.py"
+    },
+    "arduino": {
+      "package": "framework-arduino",
+      "script": "builder/frameworks/arduino.py"
     }
   },
   "packages": {
     "toolchain-gccarmnoneeabi": {
       "type": "toolchain",
       "owner": "platformio",
-      "version": "~1.80201.0",
-      "optionalVersions": [
-        "~1.90201.0"
-      ]
+      "version": "~1.120301.0"
+    },
+    "framework-arduino-silabs": {
+      "type": "framework",
+      "optional": true,
+      "version": "https://github.com/SiliconLabs/arduino.git"
     },
     "framework-mbed": {
       "type": "framework",


### PR DESCRIPTION
This adds some as some initial boilerplate code for a platform builder script for https://github.com/SiliconLabs/arduino .
That's the official Arduino core for the upcoming Arduino Nano Matter board.

It also adds a board definition for the Sparkfun Thing Plus Matter board. I'm fairly sure I've deduced the correct MCU data for this board from its spec sheet and some other pointers but I can't guarantee it is _actually_ an EFR32MG24B020F1536IM40.

The svd file for the MCU was sourced from
https://www.keil.arm.com/family/silicon-labs-efr32mg24-series/

---

It's unlikely I'll find the time to dive into this and finish the builder script but it might serve as a good starting for anyone looking to finish this.

If there are examples or best practices for extracting flags for (sub-)variants from Arduino's `boards.txt` and `platform.txt`, I'd appreciate pointers.

Edit: The EFR32 seemed similar enough to the EFM32 to me but it may also make sense to move this into a separate platform.